### PR TITLE
updated version of  fluent-plugin-kubernetes_metadata_filter in order…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH /home/fluent/.gem/ruby/2.3.0/bin:$PATH
 RUN set -ex \
     && apk add --no-cache --virtual .build-deps build-base ruby-dev libffi-dev \
     && echo 'gem: --no-document' >> /etc/gemrc \
-    && gem install fluent-plugin-kubernetes_metadata_filter -v 2.1.2 \
+    && gem install fluent-plugin-kubernetes_metadata_filter -v 2.3.0 \
     && gem install fluent-plugin-json-transform -v 0.0.2 \
     && gem install fluent-plugin-mutate_filter -v 1.0.7 \
     && gem install fluent-plugin-gelf-hs -v 1.0.7 \


### PR DESCRIPTION
… to fix docker build

source: https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/issues/184

error log (of failed build):
```
+ gem install fluent-plugin-kubernetes_metadata_filter -v 2.1.2
Successfully installed public_suffix-4.0.2
Successfully installed addressable-2.7.0
Building native extensions.  This could take a while...
ERROR:  Error installing fluent-plugin-kubernetes_metadata_filter:
	activesupport requires Ruby version >= 2.5.0.
```